### PR TITLE
ActionView 6.1 support

### DIFF
--- a/lib/apipie_dsl/tasks_utils.rb
+++ b/lib/apipie_dsl/tasks_utils.rb
@@ -25,7 +25,8 @@ module ApipieDSL
         layouts_paths.unshift("#{Rails.root}/app/views/layouts")
       end
       paths = ActionView::PathSet.new(base_paths + layouts_paths)
-      @renderer = ActionView::Base.new(paths, {})
+      lookup_context = ActionView::LookupContext.new(paths)
+      @renderer = ActionView::Base.with_empty_template_cache.new(lookup_context, {}, nil)
       @renderer.singleton_class.send(:include, ::ApipieDslHelper)
       @renderer
     end


### PR DESCRIPTION
From the 6.1 changelog:

* Require that `ActionView::Base` subclasses implement `#compiled_method_container`.
* Remove deprecated support to pass an object that is not a `ActionView::LookupContext` as the first argument in `ActionView::Base#initialize`.

Also, all params of `ActionView::Base#initialize` became required in https://github.com/rails/rails/commit/cd0c99c991ecbdb60b87cf648a6fddb0a50a13ad

To the best of my understanding, this is compatible with 6.0, but I did not explicitly test it.